### PR TITLE
CRW-4585: fix CVE issues

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 plugins {
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.1.0'
+    id 'org.springframework.boot' version '3.1.4'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'
@@ -39,7 +39,8 @@ def versions = [
     httpclient5: '5.2.1',
     jaxb_api: '2.3.1',
     jaxb_impl: '2.3.8',
-    snakeyaml: '2.0'
+    snakeyaml: '2.0',
+    xmlbeans: '5.1.1'
 ]
 
 ext['snakeyaml.version'] = versions.snakeyaml
@@ -67,6 +68,7 @@ configurations {
 }
 
 dependencies {
+    implementation "org.apache.xmlbeans:xmlbeans:${versions.xmlbeans}"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,8 +38,11 @@ def versions = [
     commons_lang3: '3.12.0',
     httpclient5: '5.2.1',
     jaxb_api: '2.3.1',
-    jaxb_impl: '2.3.8'
+    jaxb_impl: '2.3.8',
+    snakeyaml: '2.0'
 ]
+
+ext['snakeyaml.version'] = versions.snakeyaml
 ext['junit-jupiter.version'] = versions.junit
 sourceCompatibility = versions.java
 


### PR DESCRIPTION
This PR provides a few updates to fix CVE issues:

CVE-2023-34034 - by updating **spring-security-config** from 6.1.0 to 6.1.4
CVE-2021-23926 - by updating **org.apache.xmlbeans:xmlbeans** from 2.6.0 to 5.1.1
CVE-2022-1471 - by updating **org.yaml:snakeyaml** from 1.3 to 2.0

Related issue: https://issues.redhat.com/browse/CRW-4585