### PR TITLE
Fix CVE-2023-4043

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -42,7 +42,8 @@ def versions = [
     jaxb_impl: '2.3.8',
     gatling: '3.9.5',
     snakeyaml: '2.0',
-    xmlbeans: '5.1.1'
+    xmlbeans: '5.1.1',
+    elasticsearch_java: '8.12.1'
 ]
 
 ext['snakeyaml.version'] = versions.snakeyaml
@@ -73,6 +74,7 @@ configurations {
 
 dependencies {
     implementation "org.apache.xmlbeans:xmlbeans:${versions.xmlbeans}"
+    implementation "co.elastic.clients:elasticsearch-java:${versions.elasticsearch_java}"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -74,6 +74,7 @@ configurations {
 
 dependencies {
     implementation "org.apache.xmlbeans:xmlbeans:${versions.xmlbeans}"
+    // fix CVE-2023-4043 
     implementation "org.eclipse.parsson:parsson:${versions.parsson}"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -43,7 +43,7 @@ def versions = [
     gatling: '3.9.5',
     snakeyaml: '2.0',
     xmlbeans: '5.1.1',
-    elasticsearch_java: '8.12.1'
+    parsson: '1.0.5'
 ]
 
 ext['snakeyaml.version'] = versions.snakeyaml
@@ -74,7 +74,7 @@ configurations {
 
 dependencies {
     implementation "org.apache.xmlbeans:xmlbeans:${versions.xmlbeans}"
-    implementation "co.elastic.clients:elasticsearch-java:${versions.elasticsearch_java}"
+    implementation "org.eclipse.parsson:parsson:${versions.parsson}"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"


### PR DESCRIPTION
Set 1.0.5 as a version for org.eclipse.parsson:parsson to fix CVE-2023-4043

```
+--- org.springframework.boot:spring-boot-starter-data-elasticsearch -> 3.1.4
|    +--- org.springframework.boot:spring-boot-starter:3.1.4 (*)
|    \--- org.springframework.data:spring-data-elasticsearch:5.1.4
|         +--- org.springframework:spring-context:6.0.12 (*)
|         +--- org.springframework:spring-tx:6.0.12 (*)
|         +--- org.springframework.data:spring-data-commons:3.1.4 (*)
|         +--- co.elastic.clients:elasticsearch-java:8.7.1
|         |    +--- org.elasticsearch.client:elasticsearch-rest-client:8.7.1
|         |    |    +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14
|         |    |    |    +--- org.apache.httpcomponents:httpcore:4.4.16
|         |    |    |    \--- commons-codec:commons-codec:1.11 -> 1.15
|         |    |    +--- org.apache.httpcomponents:httpcore:4.4.13 -> 4.4.16
|         |    |    +--- org.apache.httpcomponents:httpasyncclient:4.1.5
|         |    |    +--- org.apache.httpcomponents:httpcore-nio:4.4.13 -> 4.4.16
|         |    |    \--- commons-codec:commons-codec:1.15
|         |    +--- com.google.code.findbugs:jsr305:3.0.2
|         |    +--- jakarta.json:jakarta.json-api:2.0.1 -> 2.1.2
|         |    \--- org.eclipse.parsson:parsson:1.0.0 -> 1.0.5 (*)
```