### PR TITLE
fix: set fix version of reactor-netty-http to fix CVE-2023-34062

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -43,6 +43,7 @@ def versions = [
     gatling: '3.9.5',
     snakeyaml: '2.0',
     xmlbeans: '5.1.1',
+    reactor_netty: '1.1.15',
     parsson: '1.0.5'
 ]
 
@@ -76,6 +77,8 @@ dependencies {
     implementation "org.apache.xmlbeans:xmlbeans:${versions.xmlbeans}"
     // fix CVE-2023-4043 
     implementation "org.eclipse.parsson:parsson:${versions.parsson}"
+    // fix CVE-2023-34062
+    implementation "io.projectreactor.netty:reactor-netty-http:${versions.reactor_netty}"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRW-5312

![screenshot-nimbusweb me-2024 02 16-16_56_40](https://github.com/che-incubator/che-openvsx/assets/1271546/b9f273b4-24fe-4b7b-b855-8c95acd2aab4)


Use reactor-netty-http:1.1.15 to fix CVE-2023-34062